### PR TITLE
0.2.0+1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Changelog
 
+## 0.2.0+1.4.0
+
+- **BREAKING**: `longhorn_nodes` variable was replaced by `longhorn_nodes_user` and `longhorn_nodes_system` variables.
+- introduce `longhorn_label_nodes` variable to let the role set labels on the K8s worker nodes.
+- introduce `longhorn_node_selector_user` and `longhorn_node_selector_system` variable. This makes it possible to run Longhorn user and system components on specific K8s nodes which have a specific node label set.
+- introduce `longhorn_action` `add-node-label` and `remove-node-label`.
+- set default `longhorn_action` in `molecule/default/converge.yml` to `template`.
+- add variables for testing node labels and node selectors to `molecule/default/group_vars/all.yml`.
+- change/add Ansible host groups in `molecule/default/molecule.yml` for testing node labels and node selectors.
+- rename `action` variable to `cilium_action` in `molecule/default/prepare.yml`
+- add tasks for K8s node labeling
+- handle K8s node labeling in `tasks/(delete|install|upgrade).yml`
+- change order of execution in `tasks/main.yml`. Task `Set default action...` should run before `Execute OS specific tasks` task
+- `templates/longhorn_values_default.yml.j2`: add `csi.kubeletRootDir` property / add more comments / add `storageMinimalAvailablePercentage: 10` value / add `replicaAutoBalance: best-effort` value / add handling for K8s node labels
+
 ## 0.1.0+1.4.0
 
 - initial commit for Longhorn `v1.4.0`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ longhorn_template_output_directory: "{{ '~/longhorn/template' | expanduser }}"
 # should run. That's mainly the following components:
 #
 # - Manager
-# - Driver
+# - Driver Deployer
 # - UI
 # - ConversionWebhook
 # - AdmissionWebhook
@@ -127,11 +127,17 @@ longhorn_label_nodes: false
 # the labels are either set somewhere else outside this role or enable
 # "longhorn_label_nodes" variable.
 #
+# For more information what possible consequences it has to run Longhorn
+# components only on specific Kubernetes nodes please also read an
+# entry in the Longhorn knowledge base:
+# Tip: Set Longhorn To Only Use Storage On A Specific Set Of Nodes
+# https://longhorn.io/kb/tip-only-use-storage-on-a-set-of-nodes/
+#
 # This/these node selector(s) will be used for the followning Longhorn
 # "user components":
 #
 # - Manager
-# - Driver
+# - Driver Deployer
 # - UI
 # - ConversionWebhook
 # - AdmissionWebhook
@@ -148,9 +154,11 @@ longhorn_label_nodes: false
 # it afterwards is no fun...
 #
 # Remove the comment (#) in-front of the next two lines to enable the
-# setting.
+# setting. The label key "longhorn.components" and its value
+# "user" are just examples. You can use whatever valid label key name and
+# key value you want of course.
 # longhorn_node_selector_user:
-#   longhorn-system-components: "true"
+#   longhorn.components: user
 
 # Basically same as above but for "system components". That's basically:
 #
@@ -159,7 +167,7 @@ longhorn_label_nodes: false
 # - CSI Driver
 #
 # longhorn_node_selector_system:
-#   longhorn-user-components: "true"
+#   longhorn.components: system
 
 # Enable multipathd blacklist. For more information see:
 # https://longhorn.io/kb/troubleshooting-volume-with-multipath/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ longhorn_template_output_directory: "{{ '~/longhorn/template' | expanduser }}"
 # should run. That's mainly the following components:
 #
 # - Manager
-# - Driver
+# - Driver Deployer
 # - UI
 # - ConversionWebhook
 # - AdmissionWebhook
@@ -87,11 +87,17 @@ longhorn_label_nodes: false
 # the labels are either set somewhere else outside this role or enable
 # "longhorn_label_nodes" variable.
 #
+# For more information what possible consequences it has to run Longhorn
+# components only on specific Kubernetes nodes please also read an
+# entry in the Longhorn knowledge base:
+# Tip: Set Longhorn To Only Use Storage On A Specific Set Of Nodes
+# https://longhorn.io/kb/tip-only-use-storage-on-a-set-of-nodes/
+#
 # This/these node selector(s) will be used for the followning Longhorn
 # "user components":
 #
 # - Manager
-# - Driver
+# - Driver Deployer
 # - UI
 # - ConversionWebhook
 # - AdmissionWebhook
@@ -108,9 +114,11 @@ longhorn_label_nodes: false
 # it afterwards is no fun...
 #
 # Remove the comment (#) in-front of the next two lines to enable the
-# setting.
+# setting. The label key "longhorn.components" and its value
+# "user" are just examples. You can use whatever valid label key name and
+# key value you want of course.
 # longhorn_node_selector_user:
-#   longhorn-system-components: "true"
+#   longhorn.components: user
 
 # Basically same as above but for "system components". That's basically:
 #
@@ -119,7 +127,7 @@ longhorn_label_nodes: false
 # - CSI Driver
 #
 # longhorn_node_selector_system:
-#   longhorn-user-components: "true"
+#   longhorn.components: system
 
 # Enable multipathd blacklist. For more information see:
 # https://longhorn.io/kb/troubleshooting-volume-with-multipath/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,15 +37,93 @@ longhorn_helm_show_commands: false
 # "longhorn/template" in users "$HOME" directory.
 longhorn_template_output_directory: "{{ '~/longhorn/template' | expanduser }}"
 
-# The Ansible group name of the nodes where Longhorn will store data
-# or replicas of the data. As the role needs to install a few OS packages
-# on that nodes the role needs to know on which hosts the tools/packages
-# are needed. E.g. if Longhorn should only be installed on nodes with a
-# specific label or taint then only these nodes need the packages installed.
-longhorn_nodes: "k8s_longhorn"
+# The Ansible group name of the nodes where the Longhorn "user components"
+# should run. That's mainly the following components:
+#
+# - Manager
+# - Driver
+# - UI
+# - ConversionWebhook
+# - AdmissionWebhook
+# - RecoveryBackend
+#
+# As the role needs to install a few OS packages on that node, the role
+# needs to know on which hosts the tools/packages should be installed.
+#
+# If Longhorn "system" and "user" components should run on the same nodes
+# just put the same group members into "longhorn_nodes_user" and
+# "longhorn_nodes_system" group.
+#
+# This group is also used if you want the role to put a label on the
+# group members and/or if a node selector should be used (see below)
+# to schedule "user components" only on a specific set of K8s nodes.
+longhorn_nodes_user: "k8s_longhorn_user"
+
+# Basically same as above but for "system components". That's basically:
+#
+# - Instance Manager
+# - Engine Image
+# - CSI Driver
+#
+# This group is also used if you want the role to put a label on the
+# group members and/or if a node selector should be used (see below)
+# to schedule "user components" only on a specific set of K8s nodes.
+longhorn_nodes_system: "k8s_longhorn_system"
+
+# Set this to "true" if the Kubernetes nodes defined in the host groups
+# specified in "longhorn_nodes_(user|system)" should be labeled. This is
+# useful if the Longhorn pods should run only on a specific set of K8s
+# hosts. If set to "true" then also "longhorn_node_selector_(user|system)"
+# must be specified (see below). The node selector keys and values
+# specified there will also be used for the node labels. You can also
+# set the labels outside this role of course. In this case leave this
+# value to "false" and only set "longhorn_node_selector_(user|system)".
+longhorn_label_nodes: false
+
+# If the Longhorn pods should only run on a specific set of nodes with
+# specific labels then these labels can be specified here. The keys and
+# values defined here are also used to label the nodes in "longhorn_nodes_user"
+# group if "longhorn_label_nodes" is set to "true". So make sure that
+# the labels are either set somewhere else outside this role or enable
+# "longhorn_label_nodes" variable.
+#
+# This/these node selector(s) will be used for the followning Longhorn
+# "user components":
+#
+# - Manager
+# - Driver
+# - UI
+# - ConversionWebhook
+# - AdmissionWebhook
+# - RecoveryBackend
+#
+# WARNING: Since all Longhorn components will be restarted, the Longhorn
+# system is unavailable temporarily. Make sure all Longhorn volumes are
+# detached! If there are running Longhorn volumes in the system, this
+# means the Longhorn system cannot restart its components and the
+# request will be rejected. Don’t operate the Longhorn system while
+# node selector settings are updated and Longhorn components are being
+# restarted. So it makes very much sense to settle on how the Longhorn
+# components should be distributed BEFORE deployment of Longhorn. Changing
+# it afterwards is no fun...
+#
+# Remove the comment (#) in-front of the next two lines to enable the
+# setting.
+# longhorn_node_selector_user:
+#   longhorn-system-components: "true"
+
+# Basically same as above but for "system components". That's basically:
+#
+# - Instance Manager
+# - Engine Image
+# - CSI Driver
+#
+# longhorn_node_selector_system:
+#   longhorn-user-components: "true"
 
 # Enable multipathd blacklist. For more information see:
 # https://longhorn.io/kb/troubleshooting-volume-with-multipath/
+# In general it makes normally sense to have these settings enabled.
 # longhorn_multipathd_blacklist_directory: "/etc/multipath/conf.d"
 # longhorn_multipathd_blacklist_directory_perm: "0755"
 # longhorn_multipathd_blacklist_file: "10-longhorn.conf"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,14 +11,14 @@
       vars:
         #
         # Install
-        #longhorn_action: "install"
+        # longhorn_action: "install"
         #
         # Upgrade
-        #longhorn_action: "upgrade"
+        # longhorn_action: "upgrade"
         #
         # Render Helm chart only
-        #longhorn_action: "template"
+        longhorn_action: "template"
         #
         # Delete all resources
-        #longhorn_action: "delete"
-        #longhorn_delete: "true"
+        # longhorn_action: "delete"
+        # longhorn_delete: "true"

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -158,9 +158,9 @@ longhorn_multipathd_blacklist_file: "10-longhorn.conf"
 longhorn_multipathd_blacklist_file_perm: "0644"
 longhorn_label_nodes: true
 longhorn_node_selector_user:
-  longhorn-user-components: "true"
+  longhorn.components: user
 longhorn_node_selector_system:
-  longhorn-system-components: "true"
+  longhorn.components: system
 
 lvm_vgs:
   - vgname: vg01

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -151,7 +151,6 @@ cilium_etcd_interface: "{{ k8s_interface }}"
 
 longhorn_delegate_to: "test-longhorn-assets"
 longhorn_helm_show_commands: true
-longhorn_nodes: "k8s_longhorn"
 longhorn_multipathd_blacklist_directory: "/etc/multipath/conf.d"
 longhorn_multipathd_blacklist_directory_perm: "0755"
 longhorn_multipathd_blacklist_file: "10-longhorn.conf"

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -150,12 +150,17 @@ cilium_helm_show_commands: true
 cilium_etcd_interface: "{{ k8s_interface }}"
 
 longhorn_delegate_to: "test-longhorn-assets"
-longhorn_helm_show_commands: false
+longhorn_helm_show_commands: true
 longhorn_nodes: "k8s_longhorn"
 longhorn_multipathd_blacklist_directory: "/etc/multipath/conf.d"
 longhorn_multipathd_blacklist_directory_perm: "0755"
 longhorn_multipathd_blacklist_file: "10-longhorn.conf"
 longhorn_multipathd_blacklist_file_perm: "0644"
+longhorn_label_nodes: true
+longhorn_node_selector_user:
+  longhorn-user-components: "true"
+longhorn_node_selector_system:
+  longhorn-system-components: "true"
 
 lvm_vgs:
   - vgname: vg01

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -81,7 +81,6 @@ platforms:
       - lvm
       - k8s_worker
       - k8s_longhorn_system
-      - k8s_longhorn_user
       - k8s
     interfaces:
       - auto_config: true
@@ -98,6 +97,7 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
+      - k8s_longhorn_system
       - k8s_longhorn_user
       - k8s
     interfaces:
@@ -116,7 +116,6 @@ platforms:
       - lvm
       - k8s_worker
       - k8s_longhorn_user
-      - k8s_longhorn_system
       - k8s
     interfaces:
       - auto_config: true
@@ -133,7 +132,7 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
-      - k8s_longhorn_system
+      - k8s_longhorn_user
       - k8s
     interfaces:
       - auto_config: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -80,7 +80,8 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
-      - k8s_longhorn
+      - k8s_longhorn_system
+      - k8s_longhorn_user
       - k8s
     interfaces:
       - auto_config: true
@@ -97,7 +98,7 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
-      - k8s_longhorn
+      - k8s_longhorn_user
       - k8s
     interfaces:
       - auto_config: true
@@ -114,7 +115,8 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
-      - k8s_longhorn
+      - k8s_longhorn_user
+      - k8s_longhorn_system
       - k8s
     interfaces:
       - auto_config: true
@@ -131,7 +133,7 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
-      - k8s_longhorn
+      - k8s_longhorn_system
       - k8s
     interfaces:
       - auto_config: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -164,7 +164,7 @@
       ansible.builtin.include_role:
         name: githubixx.cilium_kubernetes
       vars:
-        action: "install"
+        cilium_action: "install"
 
 - name: Taint Kubernetes control plane nodes
   hosts: k8s_assets

--- a/tasks/add-node-label.yml
+++ b/tasks/add-node-label.yml
@@ -1,0 +1,15 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Include nodes_label_user.yml
+  ansible.builtin.include_tasks:
+    file: includes/nodes_label_user.yml
+  vars:
+    longhorn__label_state: "add"
+
+- name: Include nodes_label_system.yml
+  ansible.builtin.include_tasks:
+    file: includes/nodes_label_system.yml
+  vars:
+    longhorn__label_state: "add"

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -70,3 +70,15 @@
         state: "absent"
       delegate_to: "{{ longhorn_delegate_to }}"
       run_once: true
+
+    - name: Include nodes_label_user.yml
+      ansible.builtin.include_tasks:
+        file: includes/nodes_label_user.yml
+      vars:
+        longhorn__label_state: "remove"
+ 
+    - name: Include nodes_label_system.yml
+      ansible.builtin.include_tasks:
+        file: includes/nodes_label_system.yml
+      vars:
+        longhorn__label_state: "remove"

--- a/tasks/delete.yml
+++ b/tasks/delete.yml
@@ -76,7 +76,7 @@
         file: includes/nodes_label_user.yml
       vars:
         longhorn__label_state: "remove"
- 
+
     - name: Include nodes_label_system.yml
       ansible.builtin.include_tasks:
         file: includes/nodes_label_system.yml

--- a/tasks/includes/nodes_label_system.yml
+++ b/tasks/includes/nodes_label_system.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Handle K8s node labels for system managed Longhorn components
+  when:
+    - longhorn_label_nodes
+    - longhorn_node_selector_system is defined
+  kubernetes.core.k8s_json_patch:
+    api_version: "v1"
+    kind: "Node"
+    name: "{{ k8s_longhorn_node }}"
+    patch: "{{ lookup('template', 'label_system.yml.j2') | from_yaml }}"
+  loop: "{{ groups[longhorn_nodes_system] }}"
+  loop_control:
+    loop_var: k8s_longhorn_node
+  run_once: true
+  delegate_to: "{{ longhorn_delegate_to }}"
+  tags:
+    - skip_ansible_lint

--- a/tasks/includes/nodes_label_user.yml
+++ b/tasks/includes/nodes_label_user.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Handle K8s node labels for user managed Longhorn components
+  when:
+    - longhorn_label_nodes
+    - longhorn_node_selector_user is defined
+  kubernetes.core.k8s_json_patch:
+    api_version: "v1"
+    kind: "Node"
+    name: "{{ k8s_longhorn_node }}"
+    patch: "{{ lookup('template', 'label_user.yml.j2') | from_yaml }}"
+  loop: "{{ groups[longhorn_nodes_user] }}"
+  loop_control:
+    loop_var: k8s_longhorn_node
+  run_once: true
+  delegate_to: "{{ longhorn_delegate_to }}"
+  tags:
+    - skip_ansible_lint

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,15 +15,15 @@
   ansible.builtin.include_tasks:
     file: includes/helm_repository.yml
 
-- name: Include label_nodes_user.yml
+- name: Include nodes_label_user.yml
   ansible.builtin.include_tasks:
-    file: includes/label_nodes_user.yml
+    file: includes/nodes_label_user.yml
   vars:
     longhorn__label_state: "replace"
 
-- name: Include label_nodes_system.yml
+- name: Include nodes_label_system.yml
   ansible.builtin.include_tasks:
-    file: includes/label_nodes_system.yml
+    file: includes/nodes_label_system.yml
   vars:
     longhorn__label_state: "replace"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,6 +15,18 @@
   ansible.builtin.include_tasks:
     file: includes/helm_repository.yml
 
+- name: Include label_nodes_user.yml
+  ansible.builtin.include_tasks:
+    file: includes/label_nodes_user.yml
+  vars:
+    longhorn__label_state: "replace"
+
+- name: Include label_nodes_system.yml
+  ansible.builtin.include_tasks:
+    file: includes/label_nodes_system.yml
+  vars:
+    longhorn__label_state: "replace"
+
 - name: Install Longhorn via Helm
   block:
     - name: Create temporary file for Helm values

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,10 +21,17 @@
   tags:
     - always
 
-- name: Execute OS specific tasks
+- name: Set default action to only render template via Helm
   when:
-    - groups[longhorn_nodes] is defined
-    - inventory_hostname in groups[longhorn_nodes]
+    - longhorn_action is not defined
+  ansible.builtin.set_fact:
+    longhorn_action: "template"
+  delegate_to: "{{ longhorn_delegate_to }}"
+  run_once: true
+
+- name: Execute OS specific tasks
+  when: (longhorn_action != "delete") and
+        (inventory_hostname in groups[longhorn_nodes_system] or inventory_hostname in groups[longhorn_nodes_user])
   ansible.builtin.include_tasks:
     file: "{{ item }}"
   with_first_found:
@@ -33,14 +40,6 @@
     - "os/{{ ansible_distribution | lower }}-{{ ansible_distribution_release }}.yml"
     - "os/{{ ansible_distribution | lower }}.yml"
     - "os/{{ ansible_os_family | lower }}.yml"
-
-- name: Set default action to only render template via Helm
-  when:
-    - longhorn_action is not defined
-  ansible.builtin.set_fact:
-    longhorn_action: "template"
-  delegate_to: "{{ longhorn_delegate_to }}"
-  run_once: true
 
 - name: Include tasks to execute requested action
   ansible.builtin.include_tasks:

--- a/tasks/remove-node-label.yml
+++ b/tasks/remove-node-label.yml
@@ -1,0 +1,15 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Include nodes_label_user.yml
+  ansible.builtin.include_tasks:
+    file: includes/nodes_label_user.yml
+  vars:
+    longhorn__label_state: "remove"
+
+- name: Include nodes_label_system.yml
+  ansible.builtin.include_tasks:
+    file: includes/nodes_label_system.yml
+  vars:
+    longhorn__label_state: "remove"

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -33,6 +33,7 @@
         chart_ref: "{{ longhorn_chart_name }}"
         chart_version: "{{ longhorn_chart_version }}"
         release_namespace: "{{ longhorn_namespace }}"
+        force: true
         create_namespace: false
         update_repo_cache: true
         values_files:

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -2,6 +2,18 @@
 # Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Include label_nodes_user.yml
+  ansible.builtin.include_tasks:
+    file: includes/label_nodes_user.yml
+  vars:
+    longhorn__label_state: "replace"
+
+- name: Include label_nodes_system.yml
+  ansible.builtin.include_tasks:
+    file: includes/label_nodes_system.yml
+  vars:
+    longhorn__label_state: "replace"
+
 - name: Upgrade Longhorn via Helm
   block:
     - name: Create temporary file for Helm values

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -2,15 +2,15 @@
 # Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Include label_nodes_user.yml
+- name: Include nodes_label_user.yml
   ansible.builtin.include_tasks:
-    file: includes/label_nodes_user.yml
+    file: includes/nodes_label_user.yml
   vars:
     longhorn__label_state: "replace"
 
-- name: Include label_nodes_system.yml
+- name: Include nodes_label_system.yml
   ansible.builtin.include_tasks:
-    file: includes/label_nodes_system.yml
+    file: includes/nodes_label_system.yml
   vars:
     longhorn__label_state: "replace"
 

--- a/templates/label_system.yml.j2
+++ b/templates/label_system.yml.j2
@@ -1,0 +1,5 @@
+{% for key in longhorn_node_selector_system.keys() %}
+- op: "{{ longhorn__label_state }}"
+  path: "/metadata/labels/{{ key }}"
+  value: "{{ longhorn_node_selector_system[key] }}" 
+{% endfor %}

--- a/templates/label_user.yml.j2
+++ b/templates/label_user.yml.j2
@@ -1,0 +1,5 @@
+{% for key in longhorn_node_selector_user.keys() %}
+- op: "{{ longhorn__label_state }}"
+  path: "/metadata/labels/{{ key }}"
+  value: "{{ longhorn_node_selector_user[key] }}" 
+{% endfor %}

--- a/templates/longhorn_values_default.yml.j2
+++ b/templates/longhorn_values_default.yml.j2
@@ -7,23 +7,39 @@
 # https://github.com/longhorn/longhorn/blob/v1.4.0/chart/values.yaml
 #
 
-persistence:
-  defaultClass: true
-  defaultFsType: ext4
-  defaultMkfsParams: "-m 1"
-  defaultClassReplicaCount: 3
+# These default settings is only for a Longhorn system that hasn’t been
+# deployed. It has no impact on an existing Longhorn system. Changing
+# settings for a running Longhorn deployment should only be done in
+# "Settings" via the "Longhorn UI".
+defaultSettings:
+  # If no other disks exist, create the default disk automatically,
+  # only on nodes with the Kubernetes label
+  # "node.longhorn.io/create-default-disk=true"
+  # If disabled, the default disk will be created on all new nodes
+  # when the node is detected for the first time.
+  createDefaultDiskLabeledNodes: false
+
+  # Default path to use for storing data on a host.
+  defaultDataPath: /var/lib/longhorn
+
+  # See above.
   defaultDataLocality: best-effort
 
-defaultSettings:
-  createDefaultDiskLabeledNodes: false
-  defaultDataPath: /var/lib/longhorn
-  defaultDataLocality: best-effort
   # This setting should be set to false in production environment
   # to ensure the best availability of the volume. Otherwise, one
   # node down event may bring down more than one replicas of a volume.
   replicaSoftAntiAffinity: false
+
+  # The default number of replicas when a volume is created from the
+  # "Longhorn UI". For Kubernetes configuration, update the
+  # "numberOfReplicas" in the "StorageClass".
   defaultReplicaCount: 3
-  mkfsExt4Parameters: "-m 1"
+
+  # Specify the percentage of the file system blocks reserved for the
+  # super-user. The default percentage is 5% but 2% should be good
+  # enough to not waste too much disk space.
+  mkfsExt4Parameters: "-m 2"
+
   # This setting should be set to false in production environment
   # to ensure every volume have the best availability when created.
   # Because with the setting set to true, the volume creation won’t
@@ -31,9 +47,122 @@ defaultSettings:
   # So there is a risk that the cluster is running out of the spaces
   # but the user won’t be made aware immediately.
   allowVolumeCreationWithDegradedAvailability: false
+
+  # The over-provisioning percentage defines how much storage can
+  # be allocated relative to the hard drive's capacity.
   storageOverProvisioningPercentage: 100
+
+  # If the "defaultDataPath" is located on the "root" disk set this
+  # value to 25 (in percent). Otherwise "kubelet" might decide to
+  # mark a Kubernetes node as unscheduable. By default this happens
+  # if disk is 80% full. If "defaultDataPath" is on a separate disk
+  # (which makes very much sense) 10 percent are fine.
+  storageMinimalAvailablePercentage: 10
+
+  # Enable this setting automatically rebalances replicas when
+  # discovered an available node.
+  # The available global options are:
+  # - disabled:     This is the default option. No replica auto-balance
+  #                 will be done.
+  # - least-effort: This option instructs Longhorn to balance replicas
+  #                 for minimal redundancy.
+  # - best-effort:  This option instructs Longhorn to balance replicas
+  #                 for even redundancy.
+  replicaAutoBalance: best-effort
+
+  # This flag is designed to prevent Longhorn from being accidentally
+  # uninstalled which will lead to data lost. Set this flag to "true"
+  # to allow Longhorn uninstallation. If this flag "false", Longhorn
+  # uninstallation job will fail.
   deletingConfirmationFlag: false
+
+  # Restrict Longhorn "system managed" components like
+  #
+  # - instance manager
+  # - engine image
+  # - CSI driver
+  #
+  # to a particular set of nodes by specifying a set of
+  # labels that must be matched.
+  # Please also read the "IMPORTANT NOTE" note below.
+  # Same applies to this node selector.
+{% if longhorn_node_selector_system is defined %}
+  systemManagedComponentsNodeSelector:
+{%  for key in longhorn_node_selector_system.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_system[key] }}"
+{%  endfor %}
+{% endif %}
+
+#
+# IMPORTANT note about "nodeSelector" for various Longhorn user
+# components (see below):
+#
+# If you want to restrict Longhorn user components to only run on
+# particular set of nodes, you can set node selector for all
+# Longhorn components. Longhorn contains user deployed
+# components (e.g, Longhorn manager, Longhorn driver, Longhorn UI)
+# and system managed components (e.g, instance manager,
+# engine image, CSI driver, etc.) You must follow the below order
+# when set the node selector:
+#
+# - Set node selector for Longhorn "user components" below
+# - Set node selector for Longhorn "system components" via
+#   default variable "systemManagedComponentsNodeSelector" (see
+#   above).
+#
+# It's recommended to set the node selector during Longhorn deployment
+# because the Longhorn system cannot be operated during the update!
+# So if you change the "nodeSelector" for the system managed
+# components via Longhorn UI as mentioned above you MUST DETACH
+# ALL VOLUMES first! That's no fun ;-) So set this once and never
+# touch again :D
 
 longhornManager:
   log:
     format: json
+{% if longhorn_node_selector_user is defined %}
+  nodeSelector:
+{%  for key in longhorn_node_selector_user.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_user[key] }}"
+{%  endfor %}
+{% endif %}
+
+longhornDriver:
+{% if longhorn_node_selector_user is defined %}
+  nodeSelector:
+{%  for key in longhorn_node_selector_user.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_user[key] }}"
+{%  endfor %}
+{% endif %}
+
+longhornUI:
+{% if longhorn_node_selector_user is defined %}
+  nodeSelector:
+{%  for key in longhorn_node_selector_user.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_user[key] }}"
+{%  endfor %}
+{% endif %}
+
+longhornConversionWebhook:
+{% if longhorn_node_selector_user is defined %}
+  nodeSelector:
+{%  for key in longhorn_node_selector_user.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_user[key] }}"
+{%  endfor %}
+{% endif %}
+
+longhornAdmissionWebhook:
+{% if longhorn_node_selector_user is defined %}
+  nodeSelector:
+{%  for key in longhorn_node_selector_user.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_user[key] }}"
+{%  endfor %}
+{% endif %}
+
+longhornRecoveryBackend:
+{% if longhorn_node_selector_user is defined %}
+  nodeSelector:
+{%  for key in longhorn_node_selector_user.keys() %}
+    {{ key }}: "{{ longhorn_node_selector_user[key] }}"
+{%  endfor %}
+{% endif %}

--- a/templates/longhorn_values_default.yml.j2
+++ b/templates/longhorn_values_default.yml.j2
@@ -7,6 +7,9 @@
 # https://github.com/longhorn/longhorn/blob/v1.4.0/chart/values.yaml
 #
 
+csi:
+  kubeletRootDir: /var/lib/kubelet
+
 # These default settings is only for a Longhorn system that hasn’t been
 # deployed. It has no impact on an existing Longhorn system. Changing
 # settings for a running Longhorn deployment should only be done in
@@ -87,10 +90,7 @@ defaultSettings:
   # Please also read the "IMPORTANT NOTE" note below.
   # Same applies to this node selector.
 {% if longhorn_node_selector_system is defined %}
-  systemManagedComponentsNodeSelector:
-{%  for key in longhorn_node_selector_system.keys() %}
-    {{ key }}: "{{ longhorn_node_selector_system[key] }}"
-{%  endfor %}
+  systemManagedComponentsNodeSelector: "{%  for key in longhorn_node_selector_system.keys() %}{{ key }}: {{ longhorn_node_selector_system[key] }}{% if not loop.last %},{% endif %}{%  endfor %}"
 {% endif %}
 
 #
@@ -127,40 +127,40 @@ longhornManager:
 {%  endfor %}
 {% endif %}
 
+{% if longhorn_node_selector_user is defined %}
 longhornDriver:
-{% if longhorn_node_selector_user is defined %}
   nodeSelector:
 {%  for key in longhorn_node_selector_user.keys() %}
     {{ key }}: "{{ longhorn_node_selector_user[key] }}"
 {%  endfor %}
 {% endif %}
 
+{% if longhorn_node_selector_user is defined %}
 longhornUI:
-{% if longhorn_node_selector_user is defined %}
   nodeSelector:
 {%  for key in longhorn_node_selector_user.keys() %}
     {{ key }}: "{{ longhorn_node_selector_user[key] }}"
 {%  endfor %}
 {% endif %}
 
+{% if longhorn_node_selector_user is defined %}
 longhornConversionWebhook:
-{% if longhorn_node_selector_user is defined %}
   nodeSelector:
 {%  for key in longhorn_node_selector_user.keys() %}
     {{ key }}: "{{ longhorn_node_selector_user[key] }}"
 {%  endfor %}
 {% endif %}
 
+{% if longhorn_node_selector_user is defined %}
 longhornAdmissionWebhook:
-{% if longhorn_node_selector_user is defined %}
   nodeSelector:
 {%  for key in longhorn_node_selector_user.keys() %}
     {{ key }}: "{{ longhorn_node_selector_user[key] }}"
 {%  endfor %}
 {% endif %}
 
-longhornRecoveryBackend:
 {% if longhorn_node_selector_user is defined %}
+longhornRecoveryBackend:
   nodeSelector:
 {%  for key in longhorn_node_selector_user.keys() %}
     {{ key }}: "{{ longhorn_node_selector_user[key] }}"


### PR DESCRIPTION
- **BREAKING**: `longhorn_nodes` variable was replaced by `longhorn_nodes_user` and `longhorn_nodes_system` variables.
- introduce `longhorn_label_nodes` variable to let the role set labels on the K8s worker nodes.
- introduce `longhorn_node_selector_user` and `longhorn_node_selector_system` variable. This makes it possible to run Longhorn user and system components on specific K8s nodes which have a specific node label set.
- introduce `longhorn_action` `add-node-label` and `remove-node-label`.
- set default `longhorn_action` in `molecule/default/converge.yml` to `template`.
- add variables for testing node labels and node selectors to `molecule/default/group_vars/all.yml`.
- change/add Ansible host groups in `molecule/default/molecule.yml` for testing node labels and node selectors.
- rename `action` variable to `cilium_action` in `molecule/default/prepare.yml`
- add tasks for K8s node labeling
- handle K8s node labeling in `tasks/(delete|install|upgrade).yml`
- change order of execution in `tasks/main.yml`. Task `Set default action...` should run before `Execute OS specific tasks` task
- `templates/longhorn_values_default.yml.j2`: add `csi.kubeletRootDir` property / add more comments / add `storageMinimalAvailablePercentage: 10` value / add `replicaAutoBalance: best-effort` value / add handling for K8s node labels