### PR TITLE
Fix K8s label handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ longhorn_label_nodes: false
 # it afterwards is no fun...
 #
 # Remove the comment (#) in-front of the next two lines to enable the
-# setting. The label key "longhorn.components" and its value
-# "user" are just examples. You can use whatever valid label key name and
+# setting. The label key "longhorn.user.components" and its value
+# "yes" are just examples. You can use whatever valid label key name and
 # key value you want of course.
 # longhorn_node_selector_user:
-#   longhorn.components: user
+#   longhorn.user.components: "yes"
 
 # Basically same as above but for "system components". That's basically:
 #
@@ -167,7 +167,7 @@ longhorn_label_nodes: false
 # - CSI Driver
 #
 # longhorn_node_selector_system:
-#   longhorn.components: system
+#   longhorn.system.components: "yes"
 
 # Enable multipathd blacklist. For more information see:
 # https://longhorn.io/kb/troubleshooting-volume-with-multipath/
@@ -249,7 +249,7 @@ To set the Kubernetes node labels run:
 ansible-playbook --tags=role-longhorn-kubernetes --extra-vars longhorn_action=add-node-label k8s.yml
 ```
 
- To remove the Kubernetes node labels run:
+To remove the Kubernetes node labels run:
 
 ```bash
 ansible-playbook --tags=role-longhorn-kubernetes --extra-vars longhorn_action=remove-node-label k8s.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -114,11 +114,11 @@ longhorn_label_nodes: false
 # it afterwards is no fun...
 #
 # Remove the comment (#) in-front of the next two lines to enable the
-# setting. The label key "longhorn.components" and its value
-# "user" are just examples. You can use whatever valid label key name and
+# setting. The label key "longhorn.user.components" and its value
+# "yes" are just examples. You can use whatever valid label key name and
 # key value you want of course.
 # longhorn_node_selector_user:
-#   longhorn.components: user
+#   longhorn.user.components: "yes"
 
 # Basically same as above but for "system components". That's basically:
 #
@@ -127,7 +127,7 @@ longhorn_label_nodes: false
 # - CSI Driver
 #
 # longhorn_node_selector_system:
-#   longhorn.components: system
+#   longhorn.system.components: "yes"
 
 # Enable multipathd blacklist. For more information see:
 # https://longhorn.io/kb/troubleshooting-volume-with-multipath/

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -157,9 +157,9 @@ longhorn_multipathd_blacklist_file: "10-longhorn.conf"
 longhorn_multipathd_blacklist_file_perm: "0644"
 longhorn_label_nodes: true
 longhorn_node_selector_user:
-  longhorn.components: user
+  longhorn.user.components: "yes"
 longhorn_node_selector_system:
-  longhorn.components: system
+  longhorn.system.components: "yes"
 
 lvm_vgs:
   - vgname: vg01

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -115,6 +115,7 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
+      - k8s_longhorn_system
       - k8s_longhorn_user
       - k8s
     interfaces:
@@ -132,6 +133,7 @@ platforms:
       - vpn
       - lvm
       - k8s_worker
+      - k8s_longhorn_system
       - k8s_longhorn_user
       - k8s
     interfaces:

--- a/tasks/includes/nodes_label_system.yml
+++ b/tasks/includes/nodes_label_system.yml
@@ -2,6 +2,22 @@
 # Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Create list of hosts
+  when:
+    - longhorn_label_nodes
+    - longhorn_node_selector_user is defined
+  ansible.builtin.set_fact:
+    longhorn__hostnames_system: |-
+      [
+      {% for host in groups[longhorn_nodes_system] %}
+        {
+          "hostname": "{{ host.split('.')[0] }}",
+        },
+      {% endfor %}
+      ]
+  run_once: true
+  delegate_to: "{{ longhorn_delegate_to }}"
+
 - name: Handle K8s node labels for system managed Longhorn components
   when:
     - longhorn_label_nodes
@@ -9,9 +25,9 @@
   kubernetes.core.k8s_json_patch:
     api_version: "v1"
     kind: "Node"
-    name: "{{ k8s_longhorn_node }}"
+    name: "{{ k8s_longhorn_node.hostname }}"
     patch: "{{ lookup('template', 'label_system.yml.j2') | from_yaml }}"
-  loop: "{{ groups[longhorn_nodes_system] }}"
+  loop: "{{ longhorn__hostnames_system }}"
   loop_control:
     loop_var: k8s_longhorn_node
   run_once: true

--- a/tasks/includes/nodes_label_user.yml
+++ b/tasks/includes/nodes_label_user.yml
@@ -2,6 +2,22 @@
 # Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+- name: Create list of hosts
+  when:
+    - longhorn_label_nodes
+    - longhorn_node_selector_user is defined
+  ansible.builtin.set_fact:
+    longhorn__hostnames_user: |-
+      [
+      {% for host in groups[longhorn_nodes_user] %}
+        {
+          "hostname": "{{ host.split('.')[0] }}",
+        },
+      {% endfor %}
+      ]
+  run_once: true
+  delegate_to: "{{ longhorn_delegate_to }}"
+
 - name: Handle K8s node labels for user managed Longhorn components
   when:
     - longhorn_label_nodes
@@ -9,9 +25,9 @@
   kubernetes.core.k8s_json_patch:
     api_version: "v1"
     kind: "Node"
-    name: "{{ k8s_longhorn_node }}"
+    name: "{{ k8s_longhorn_node.hostname }}"
     patch: "{{ lookup('template', 'label_user.yml.j2') | from_yaml }}"
-  loop: "{{ groups[longhorn_nodes_user] }}"
+  loop: "{{ longhorn__hostnames_user }}"
   loop_control:
     loop_var: k8s_longhorn_node
   run_once: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -58,6 +58,7 @@
         chart_ref: "{{ longhorn_chart_name }}"
         chart_version: "{{ longhorn_chart_version }}"
         release_namespace: "{{ longhorn_namespace }}"
+        force: true
         create_namespace: false
         update_repo_cache: true
         values_files:

--- a/templates/longhorn_values_default.yml.j2
+++ b/templates/longhorn_values_default.yml.j2
@@ -8,7 +8,7 @@
 #
 
 csi:
-  kubeletRootDir: /var/lib/kubelet
+  kubeletRootDir: "/var/lib/kubelet"
 
 # These default settings is only for a Longhorn system that hasn’t been
 # deployed. It has no impact on an existing Longhorn system. Changing
@@ -20,23 +20,23 @@ defaultSettings:
   # "node.longhorn.io/create-default-disk=true"
   # If disabled, the default disk will be created on all new nodes
   # when the node is detected for the first time.
-  createDefaultDiskLabeledNodes: false
+  createDefaultDiskLabeledNodes: "false"
 
   # Default path to use for storing data on a host.
-  defaultDataPath: /var/lib/longhorn
+  defaultDataPath: "/var/lib/longhorn"
 
   # See above.
-  defaultDataLocality: best-effort
+  defaultDataLocality: "best-effort"
 
   # This setting should be set to false in production environment
   # to ensure the best availability of the volume. Otherwise, one
   # node down event may bring down more than one replicas of a volume.
-  replicaSoftAntiAffinity: false
+  replicaSoftAntiAffinity: "false"
 
   # The default number of replicas when a volume is created from the
   # "Longhorn UI". For Kubernetes configuration, update the
   # "numberOfReplicas" in the "StorageClass".
-  defaultReplicaCount: 3
+  defaultReplicaCount: "3"
 
   # Specify the percentage of the file system blocks reserved for the
   # super-user. The default percentage is 5% but 2% should be good
@@ -49,18 +49,18 @@ defaultSettings:
   # error out even there is only enough room to schedule one replica.
   # So there is a risk that the cluster is running out of the spaces
   # but the user won’t be made aware immediately.
-  allowVolumeCreationWithDegradedAvailability: false
+  allowVolumeCreationWithDegradedAvailability: "false"
 
   # The over-provisioning percentage defines how much storage can
   # be allocated relative to the hard drive's capacity.
-  storageOverProvisioningPercentage: 100
+  storageOverProvisioningPercentage: "100"
 
   # If the "defaultDataPath" is located on the "root" disk set this
   # value to 25 (in percent). Otherwise "kubelet" might decide to
   # mark a Kubernetes node as unscheduable. By default this happens
   # if disk is 80% full. If "defaultDataPath" is on a separate disk
   # (which makes very much sense) 10 percent are fine.
-  storageMinimalAvailablePercentage: 10
+  storageMinimalAvailablePercentage: "10"
 
   # Enable this setting automatically rebalances replicas when
   # discovered an available node.
@@ -71,13 +71,13 @@ defaultSettings:
   #                 for minimal redundancy.
   # - best-effort:  This option instructs Longhorn to balance replicas
   #                 for even redundancy.
-  replicaAutoBalance: best-effort
+  replicaAutoBalance: "best-effort"
 
   # This flag is designed to prevent Longhorn from being accidentally
   # uninstalled which will lead to data lost. Set this flag to "true"
   # to allow Longhorn uninstallation. If this flag "false", Longhorn
   # uninstallation job will fail.
-  deletingConfirmationFlag: false
+  deletingConfirmationFlag: "false"
 
   # Restrict Longhorn "system managed" components like
   #
@@ -90,7 +90,7 @@ defaultSettings:
   # Please also read the "IMPORTANT NOTE" note below.
   # Same applies to this node selector.
 {% if longhorn_node_selector_system is defined %}
-  systemManagedComponentsNodeSelector: "{%  for key in longhorn_node_selector_system.keys() %}{{ key }}: {{ longhorn_node_selector_system[key] }}{% if not loop.last %},{% endif %}{%  endfor %}"
+  systemManagedComponentsNodeSelector: "{%  for key in longhorn_node_selector_system.keys() %}{{ key }}:{{ longhorn_node_selector_system[key] }}{% if not loop.last %},{% endif %}{%  endfor %}"
 {% endif %}
 
 #
@@ -119,7 +119,7 @@ defaultSettings:
 
 longhornManager:
   log:
-    format: json
+    format: "json"
 {% if longhorn_node_selector_user is defined %}
   nodeSelector:
 {%  for key in longhorn_node_selector_user.keys() %}


### PR DESCRIPTION
- K8s can't handle two keys with the same name but different values. So renamed ` longhorn.components: user` to `longhorn.user.components: yes` and `longhorn.components: system` to `longhorn.system.components: yes`
- fix K8s node group handling to make it work on Ansible controller nodes different to localhost
- `templates/longhorn_values_default.yml.j2`: fix `systemManagedComponentsNodeSelector` value. Caused all settings to be completely ignored by Longhorn
- `templates/longhorn_values_default.yml.j2`: put all values into double quotes
- `tasks/install.yml`: add `force: true` property/value to install Helm chart
- `molecule/default/molecule.yml`: add two worker nodes to k8s_longhorn_system hosts group